### PR TITLE
Allow certificate paths to be http/https urls.

### DIFF
--- a/lib/vagrant-ca-certificates/config/ca_certificates.rb
+++ b/lib/vagrant-ca-certificates/config/ca_certificates.rb
@@ -1,6 +1,5 @@
 require 'vagrant'
 require 'vagrant/util/downloader'
-require 'tempfile'
 
 module VagrantPlugins
   module CaCertificates

--- a/lib/vagrant-ca-certificates/version.rb
+++ b/lib/vagrant-ca-certificates/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module CaCertificates
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,8 @@ en:
       upload:
         pre: |-
           Uploading certificates to '%{path}'...
+        download: |-
+          -- Downloading %{from}
         cert: |-
           -- %{from} => %{to}
         post: |-


### PR DESCRIPTION
Building upon the ideas presented in #2 but having the certificate downloading happen at certificate upload time.
