### PR TITLE
add deb/ubuntu updating for ruby

### DIFF
--- a/lib/vagrant-ca-certificates/cap/debian/update_certificates.rb
+++ b/lib/vagrant-ca-certificates/cap/debian/update_certificates.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
               # Add references to uploaded certificates.
               comm.sudo("find #{ca_certs} -maxdepth 1 -type f -exec basename {} \\; | sed -e 's#^#vagrant\/#' >> #{ca_config} ")
               # Update.
-              comm.sudo("find #{ca_certs} -maxdepth 1 -type f | xargs cat | tee #{ruby_ca_cert} ")
+              comm.sudo("find #{ca_certs} -maxdepth 1 -type f -exec cat {} >> #{ruby_ca_cert} \\;")
               comm.sudo("update-ca-certificates") do |type, data|
                 if [:stderr, :stdout].include?(type)
                   next if data =~ /stdin: is not a tty/


### PR DESCRIPTION
Testkitchen builds were failing on Ubuntu 12/14 due to Ruby not finding correct CA certs at (default) /usr/lib/ssl/cert.pem, Ruby will not read the system certs because reasons.

This adds writing of all included PEM encoded certs to default Ruby cert file.
