### PR TITLE
Various Fixes

### DIFF
--- a/lib/vagrant-ca-certificates/cap/debian/update_certificate_bundle.rb
+++ b/lib/vagrant-ca-certificates/cap/debian/update_certificate_bundle.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
         # Capability for configuring the certificate bundle on Debian.
         module UpdateCertificateBundle
           def self.update_certificate_bundle(m)
+            m.communicate.sudo("ls /usr/share/ca-certificates/private | awk '{print \"private/\"$1;}' >> /etc/ca-certificates.conf") # enable our custom certs
             m.communicate.sudo('update-ca-certificates') do |type, data|
               if [:stderr, :stdout].include?(type)
                 next if data =~ /stdin: is not a tty/

--- a/lib/vagrant-ca-certificates/cap/redhat/helpers.rb
+++ b/lib/vagrant-ca-certificates/cap/redhat/helpers.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         # bundles must be managed manually.
         def self.legacy_certificate_bundle?(sh)
           command = %q(R=$(sed -E "s/.* ([0-9])\.([0-9]+) .*/\\1.\\2/" /etc/redhat-release))
-          sh.test(%Q(#{command} && [[ $R =~ ^5 || $R =~ ^6\.[0-4]+ ]]), shell: '/bin/bash')
+          sh.test(%Q(#{command} && [[ $R =~ ^5 || $R =~ ^6\.[0-4]+ ]]), shell: '/bin/bash') || !sh.test("rpm -q --verify --nomtime ca-certificates", shell:'/bin/bash')
         end
       end
     end

--- a/lib/vagrant-ca-certificates/cap/redhat/update_certificate_bundle.rb
+++ b/lib/vagrant-ca-certificates/cap/redhat/update_certificate_bundle.rb
@@ -12,10 +12,11 @@ module VagrantPlugins
                 sh.sudo('find /etc/pki/tls/private -type f -exec cat {} \; | cat /etc/pki/tls/certs/ca-bundle.crt - > /etc/pki/tls/ca.private.crt')
                 sh.sudo('/bin/ln -fsn /etc/pki/tls/ca.private.crt /etc/pki/tls/cert.pem')
                 sh.execute(<<-SCRIPT, shell: '/bin/bash', sudo: true)
-[ ! -z "$JAVA_HOME" ] && \
+if [ ! -z "$JAVA_HOME" ]; then \
 find /etc/pki/tls/private -type f -exec $JAVA_HOME/bin/keytool -importcert \
  -trustcacerts -noprompt -storepass changeit \
- -keystore $JAVA_HOME/jre/lib/security/cacerts -file {} \\;
+ -keystore $JAVA_HOME/jre/lib/security/cacerts -file {} \\; \
+else true; fi
                 SCRIPT
               else
                 sh.sudo('update-ca-trust enable')

--- a/lib/vagrant-ca-certificates/cap/redhat/update_certificate_bundle.rb
+++ b/lib/vagrant-ca-certificates/cap/redhat/update_certificate_bundle.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
               if Redhat.legacy_certificate_bundle?(sh)
                 sh.sudo('find /etc/pki/tls/private -type f -exec cat {} \; | cat /etc/pki/tls/certs/ca-bundle.crt - > /etc/pki/tls/ca.private.crt')
                 sh.sudo('/bin/ln -fsn /etc/pki/tls/ca.private.crt /etc/pki/tls/cert.pem')
+                sh.sudo('/bin/ln -fsn /etc/pki/tls/ca.private.crt /etc/pki/tls/certs/ca-bundle.crt')
                 sh.execute(<<-SCRIPT, shell: '/bin/bash', sudo: true)
 if [ ! -z "$JAVA_HOME" ]; then \
 find /etc/pki/tls/private -type f -exec $JAVA_HOME/bin/keytool -importcert \

--- a/lib/vagrant-ca-certificates/plugin.rb
+++ b/lib/vagrant-ca-certificates/plugin.rb
@@ -22,11 +22,6 @@ module VagrantPlugins
         hook.after(Vagrant::Action::Builtin::Provision, Action::InstallCertificates)
       end
 
-      action_hook(:install_ca_certificates) do |hook|
-        require_relative 'action/install_certificates'
-        hook.after(:run_provisioner, Action::InstallCertificates)
-      end
-
       # All supported guest systems must have these capabilities
       # implemented. If any of them aren't config validate will fail.
       guest_capability('debian', 'update_certificate_bundle') do


### PR DESCRIPTION
Build the "to" tmp path file differently to be compatible with windows hosts
Add additional check for legacy bundle (same check update-ca-trust enable uses)
Fix plugin returning failure when java isn't installed for legacy install
Symlink ca-bundle.crt as well on legacy install on rhel (update-ca-trust symlinks ca-bundle and cert.pem, and both seem to be used)
Fix plugin running twice
Trust our uploaded certs in debian ca-certificates.conf