### PR TITLE
Adds CoreOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.DS_Store

--- a/lib/vagrant-ca-certificates/cap/coreos/certificate_file_bundle.rb
+++ b/lib/vagrant-ca-certificates/cap/coreos/certificate_file_bundle.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module CaCertificates
+    module Cap
+      module CoreOS
+        module CertificateFileBundle
+          def self.certificate_file_bundle(m)
+            '/etc/ssl/certs/ca-certificates.crt'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ca-certificates/cap/coreos/certificate_upload_path.rb
+++ b/lib/vagrant-ca-certificates/cap/coreos/certificate_upload_path.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module CaCertificates
+    module Cap
+      module CoreOS
+        module CertificateUploadPath
+          def self.certificate_upload_path(m)
+            '/etc/ssl/certs'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ca-certificates/cap/coreos/update_certificate_bundle.rb
+++ b/lib/vagrant-ca-certificates/cap/coreos/update_certificate_bundle.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module CaCertificates
+    module Cap
+      module CoreOS
+        # Capability for configuring the certificate bundle on CoreOS.
+        module UpdateCertificateBundle
+          def self.update_certificate_bundle(m)
+            m.communicate.sudo("ls /etc/ssl/certs | awk '{print \"private/\"$1;}' >> /etc/ca-certificates.conf") # enable our custom certs
+            m.communicate.sudo('update-ca-certificates') do |type, data|
+              if [:stderr, :stdout].include?(type)
+                next if data =~ /stdin: is not a tty/
+                m.env.ui.info data
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ca-certificates/plugin.rb
+++ b/lib/vagrant-ca-certificates/plugin.rb
@@ -34,6 +34,11 @@ module VagrantPlugins
         Cap::Redhat::UpdateCertificateBundle
       end
 
+      guest_capability('coreos', 'update_certificate_bundle') do
+        require_relative 'cap/coreos/update_certificate_bundle'
+        Cap::CoreOS::UpdateCertificateBundle
+      end
+
       guest_capability('debian', 'certificate_upload_path') do
         require_relative 'cap/debian/certificate_upload_path'
         Cap::Debian::CertificateUploadPath
@@ -44,6 +49,11 @@ module VagrantPlugins
         Cap::Redhat::CertificateUploadPath
       end
 
+      guest_capability('coreos', 'certificate_upload_path') do
+        require_relative 'cap/coreos/certificate_upload_path'
+        Cap::CoreOS::CertificateUploadPath
+      end
+
       guest_capability('debian', 'certificate_file_bundle') do
         require_relative 'cap/debian/certificate_file_bundle'
         Cap::Debian::CertificateFileBundle
@@ -52,6 +62,11 @@ module VagrantPlugins
       guest_capability('redhat', 'certificate_file_bundle') do
         require_relative 'cap/redhat/certificate_file_bundle'
         Cap::Redhat::CertificateFileBundle
+      end
+
+      guest_capability('coreos', 'certificate_file_bundle') do
+        require_relative 'cap/coreos/certificate_file_bundle'
+        Cap::CoreOS::CertificateFileBundle
       end
     end
   end

--- a/spec/unit/vagrant-ca-certificates/cap/coreos/certificate_upload_path_spec.rb
+++ b/spec/unit/vagrant-ca-certificates/cap/coreos/certificate_upload_path_spec.rb
@@ -1,0 +1,5 @@
+require 'vagrant-ca-certificates/cap/coreos/certificate_upload_path'
+require 'spec_helper'
+
+describe VagrantPlugins::CaCertificates::Cap::CoreOS::CertificateUploadPath do
+end

--- a/spec/unit/vagrant-ca-certificates/cap/coreos/update_certificate_bundle_spec.rb
+++ b/spec/unit/vagrant-ca-certificates/cap/coreos/update_certificate_bundle_spec.rb
@@ -1,0 +1,5 @@
+require 'vagrant-ca-certificates/cap/coreos/update_certificate_bundle'
+require 'spec_helper'
+
+describe VagrantPlugins::CaCertificates::Cap::CoreOS::UpdateCertificateBundle do
+end


### PR DESCRIPTION
CoreOS is quite similar to Debian except several parts of the filesystem are mounted as read-only.  This adds the configured certificates to `/etc/ssl/certs` instead of `/usr/share/ca-certificates/private` for that reason.