### PR TITLE
Make legacy check on RedHat idempotent

### DIFF
--- a/lib/vagrant-ca-certificates/cap/redhat/helpers.rb
+++ b/lib/vagrant-ca-certificates/cap/redhat/helpers.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         # bundles must be managed manually.
         def self.legacy_certificate_bundle?(sh)
           command = %q(R=$(sed -E "s/.* ([0-9])\.([0-9]+) .*/\\1.\\2/" /etc/redhat-release))
-          sh.test(%Q(#{command} && [[ $R =~ ^5 || $R =~ ^6\.[0-4]+ ]]), shell: '/bin/bash') || !sh.test("rpm -q --verify --nomtime ca-certificates", shell:'/bin/bash')
+          sh.test(%Q(#{command} && [[ $R =~ ^5 || $R =~ ^6\.[0-4]+ ]]), shell: '/bin/bash') || !sh.test("rpm -q ca-certificates", shell:'/bin/bash')
         end
       end
     end


### PR DESCRIPTION
This PR removes the `--verify` and `--nomtime` flags as they make the legacy check non-idempotent.

What happens is:

 1. A new Vagrant machine is created with a fresh CA store: `rpm -q --verify --nomtime ca-certificates` returns `0`
 1. This plugin runs and installs the certificates in the CA bundle
 1. You restart the vagrant box and the plugin runs again, this time the check fails:

  ```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

find /etc/pki/tls/private -type f -exec cat {} \; | cat /etc/pki/tls/certs/ca-bundle.crt - > /etc/pki/tls/ca.private.crt

Stdout from the command:



Stderr from the command:

cat: /etc/pki/tls/certs/ca-bundle.crt: input file is output file
  ```

 because:

  ```
[vagrant@node ~]$ rpm -q --verify --nomtime ca-certificates
....L....  c /etc/pki/java/cacerts
....L....  c /etc/pki/tls/certs/ca-bundle.crt
....L....  c /etc/pki/tls/certs/ca-bundle.trust.crt
[vagrant@node ~]$ echo $?
1
  ```

We don't actually care if the original files installed by `ca-certificates` have been modified, because we fully intend on modifying them, we just want to know if it's installed.