### PR TITLE
Fixes the file move after certificate is uploaded to Windows guest

### DIFF
--- a/lib/vagrant-ca-certificates/action/install_certificates.rb
+++ b/lib/vagrant-ca-certificates/action/install_certificates.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
               sh.upload(from, tmp_to) # remote.path will build a "C:\" URI on windows, cp to ~ and move.
               case @machine.guest.name
               when :windows
-                sh.sudo("Move-Item -path #{tmp_to}/* -Destination #{to} -Force")
+                sh.sudo("Move-Item -path #{tmp_to} -Destination #{to} -Force")
               else
                 sh.sudo("mv #{tmp_to} #{to} && chown root: #{to} && chmod 0644 #{to}")
               end


### PR DESCRIPTION
This plugin has been broken for Windows after Vagrant 1.9.1 due to the underlying WinRM-FS gem changed how it was performing its file upload. Previously, it was creating a directory which contained the file, now it creates a single file.

This fixes the moving of the uploaded certificate once it has been uploaded to the guest to it's final resting directory.